### PR TITLE
Change owner of /var/webdav/ to APACHE_RUN_USER

### DIFF
--- a/sources/entrypoint.sh
+++ b/sources/entrypoint.sh
@@ -80,9 +80,8 @@ if [ -z "$(ls -A $WEBDAV_USER_CONFIG_DIR)" ] || [ "$FORCE_REINIT_CONFIG" = true 
 		chown -R $APACHE_RUN_USER:$APACHE_RUN_USER $WEBDAV_USER_CONFIG_DIR
 		chmod -R 770 $WEBDAV_USER_CONFIG_DIR
 		chown -R $APACHE_RUN_USER:$APACHE_RUN_USER /var/webdav/
-		chmod -R 770 /var/webdav/
+		chown -R $APACHE_RUN_USER:$APACHE_RUN_USER /var/webdav/data || true
 	echo "[] Done."
-	
 	
 	echo "[] Running on_post_init.sh ..."
 		. $WEBDAV_SOURCE_DIR/eventscripts/on_post_init.sh || true

--- a/sources/entrypoint.sh
+++ b/sources/entrypoint.sh
@@ -79,6 +79,8 @@ if [ -z "$(ls -A $WEBDAV_USER_CONFIG_DIR)" ] || [ "$FORCE_REINIT_CONFIG" = true 
 		chmod 660 $WEBDAV_CONFIG_PATH/webdav.conf
 		chown -R $APACHE_RUN_USER:$APACHE_RUN_USER $WEBDAV_USER_CONFIG_DIR
 		chmod -R 770 $WEBDAV_USER_CONFIG_DIR
+		chown -R $APACHE_RUN_USER:$APACHE_RUN_USER /var/webdav/
+		chmod -R 770 /var/webdav/
 	echo "[] Done."
 	
 	


### PR DESCRIPTION
Hi.

I'm using image https://hub.docker.com/r/chonjay21/webdav as WebDAV server for tests purposes in CI.

But when I try to upload files to werver, I've got:
```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>403 Forbidden</title>
</head><body>
<h1>Forbidden</h1>
<p>You don't have permission to access this resource.</p>
</body></html>
```

The reason is that owner of `/var/webdav/data` is `root`, and not `www-data` user:
```
root@b103dfd68d8f:/usr/local/apache2# ls -lsah /var/webdav/
total 0
0 drwxr-xr-x 3 root root 18 Sep 19  2020 .
0 drwxr-xr-x 1 root root 17 Sep 19  2020 ..
0 drwxr-xr-x 2 root root  6 Sep 19  2020 data
root@b103dfd68d8f:/usr/local/apache2# ls -lsah /var/webdav/data/
total 0
0 drwxr-xr-x 2 root root  6 Sep 19  2020 .
0 drwxr-xr-x 3 root root 18 Sep 19  2020 ..
```

How about modifying entrypoint to change data folder owner during initialization?